### PR TITLE
deposit Form dirty dialog issue and others fixes

### DIFF
--- a/rlib/rconfig.go
+++ b/rlib/rconfig.go
@@ -14,11 +14,22 @@ var AppConfig extres.ExternalResources
 
 // RRReadConfig will read the configuration file "config.json" if
 // it exists in the current directory
-func RRReadConfig() error {
-	folderPath, err := osext.ExecutableFolder()
-	if err != nil {
-		log.Fatal(err)
+func RRReadConfig(fPath ...string) error {
+	var (
+		folderPath string
+		err        error
+	)
+
+	// as of now, just limit the paramaters upto 1 length only
+	if len(fPath) > 0 {
+		folderPath = fPath[0]
+	} else {
+		folderPath, err = osext.ExecutableFolder()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
+
 	fname := folderPath + "/config.json"
 	err = extres.ReadConfig(fname, &AppConfig)
 	if err != nil {

--- a/test/acctrule/main.go
+++ b/test/acctrule/main.go
@@ -42,7 +42,6 @@ func readCommandLineArgs() {
 func main() {
 	var err error
 	readCommandLineArgs()
-	rlib.RRReadConfig()
 
 	//----------------------------
 	// Open RentRoll database

--- a/webclient/.jshintrc
+++ b/webclient/.jshintrc
@@ -102,6 +102,7 @@
         "exportReportCSV": true,
         "exportReportPDF": true,
         "popupPDFCustomDimensions": true,
-        "saveCustomDims": true
+        "saveCustomDims": true,
+        "setDefaultFormFieldAsPreviousRecord": true
     }
 }

--- a/webclient/js/elems/deposit.js
+++ b/webclient/js/elems/deposit.js
@@ -170,17 +170,18 @@ function buildDepositElements() {
                 .done( function(dpmArgs,depArgs) {
                     if (typeof dpmArgs[0] == 'string') {
                         app.depmeth = JSON.parse(dpmArgs[0]);
-                        w2ui.depositForm.get('DPMName').options.items = app.depmeth[BUD];
+                        f.get('DPMName').options.items = app.depmeth[BUD];
                     } else if (dpmArgs[0].status != 'success') {
-                        w2ui.depositForm.message(dpmArgs[0].message);
+                        f.message(dpmArgs[0].message);
                     }
 
                     if (typeof depArgs[0] == 'string') {
                         app.Depositories = JSON.parse(depArgs[0]);
-                        w2ui.depositForm.get('DEPName').options.items = app.Depositories[BUD];
+                        f.get('DEPName').options.items = app.Depositories[BUD];
                     } else if (depArgs[0].status != 'success') {
-                        w2ui.depositForm.message(depArgs[0].message);
+                        f.message(depArgs[0].message);
                     }
+
                 })
                 .fail( function() { console.log('Error getting /v1/uival/' + x.value + '/{app.depmeth | app.Depositories}'); });
 

--- a/webclient/js/elems/deposit.js
+++ b/webclient/js/elems/deposit.js
@@ -159,7 +159,7 @@ function buildDepositElements() {
                 BID=parseInt(x.value),
                 BUD = getBUDfromBID(BID),
                 f = w2ui.depositForm;
-                var record = getDepositInitRecord(BID, BUD, f.record);
+                var record = getDepositInitRecord(BID, BUD, null);
                 f.record = record;
                 var getUIInfo = function(bid,x) {
                     return $.get('/v1/uival/' + bid + x );
@@ -250,13 +250,16 @@ function buildDepositElements() {
             event.onComplete = function() {
                 var f = this;
                 var r = f.record;
+                var x = getCurrentBusiness(),
+                    BID=parseInt(x.value),
+                    BUD = getBUDfromBID(BID);
+
                 var header = "Edit Deposit ({0})";
-                var bud = r.BUD.text;
                 var dpmid = r.DPMID;
                 var depid = r.DEPID;
 
-                f.get("DPMName").options.selected = getDepMeth(bud, dpmid);
-                f.get("DEPName").options.selected = getDepository(bud, depid);
+                f.get("DPMName").options.selected = getDepMeth(BUD, dpmid);
+                f.get("DEPName").options.selected = getDepository(BUD, depid);
                 formRefreshCallBack(f, "DID", header);
             };
         },

--- a/webclient/js/elems/layout.js
+++ b/webclient/js/elems/layout.js
@@ -20,10 +20,17 @@ function buildAppLayout(){
                     // get the form from active_form value
                     var f = w2ui[app.active_form];
                     if (f) {
-                        // if right panel is being hidden, then make blank everything related with active form
+                        // if right panel is being hidden,
+                        // then make blank everything related with active form
+
+                        // b'coz rtForm, depositForm, rentalagrForm have been
+                        // filled inside a layout, so we need to consider those
+                        // separately
                         if (f === this.get("right").content ||
                             f.name == "rtForm" ||
-                            f.name == "rentalagrForm") { // b'coz rtForm, rentalagrForm have been filled inside a layout
+                            f.name == "rentalagrForm" ||
+                            f.name === "depositForm") {
+
                             app.active_form = "";
                             app.active_form_original = {};
                             app.form_is_dirty = false;

--- a/webclient/js/elems/rutil.js
+++ b/webclient/js/elems/rutil.js
@@ -170,27 +170,6 @@ function getBIDfromBUD(BUD) {
 }
 
 //-----------------------------------------------------------------------------
-// getPaymentType - searches BUD's Payment Types for PMTID.  If found the
-//                  then payment type object is returned, else an empty object is returned.
-// @params  BUD   - the BUD for the business of interest
-//          PMTID - the payment type id for which we want the name
-// @return  the Payment Type (or empty object if not found)
-//-----------------------------------------------------------------------------
-function getPaymentType(BUD, reqPMTID) {
-    var pmt = {};
-    if (typeof BUD === "undefined") {
-        return pmt;
-    }
-    app.pmtTypes[BUD].forEach(function(item) {
-        if (item.PMTID == reqPMTID) {
-            pmt = { id: item.PMTID, text: item.Name };
-            return pmt;
-        }
-    });
-    return pmt;
-}
-
-//-----------------------------------------------------------------------------
 // getDepMeth     - searches BUD's Deposit Methods for id.  If found the
 //                  then Deposit Method object is returned, otherwise an
 //                  empty object is returned.

--- a/webclient/js/elems/rutil.js
+++ b/webclient/js/elems/rutil.js
@@ -861,7 +861,7 @@ function formRefreshCallBack(w2frm, id_name, form_header, show_header) {
         header = form_header;
 
     if (id === undefined) {
-        console.log("given id_name does not exist in form's record");
+        console.log("given id_name '"+id_name+"' does not exist in form's record");
         return false;
     }
 


### PR DESCRIPTION
**ADDED**

1. custom config.json folder path support in _**readconfig**_ routine

**FIXED**

- deposit form dirty dialog issue
- payment types changes are now reflected in the list
- RAID enabled/disabled based on AR in receiptForm, save/add, onload actions
- missing save/add action in deposit form