### PR TITLE
fees modification on rent dates change + raflow actions update + error display 

### DIFF
--- a/bizlogic/raflow.go
+++ b/bizlogic/raflow.go
@@ -747,11 +747,12 @@ func validatePetBizLogic(ctx context.Context, a *rlib.RAFlowJSONData, g *Validat
 		}
 
 		// There must be one entry for the Fees
+		// If not than display it via nonfields error
 		// ----------- Check for rule no 3 ------------
 		if !(len(pet.Fees) > 0) {
-			err = fmt.Errorf("must be at least one entry for the fees")
-			petFieldsError.Total++
-			petFieldsError.Errors["Fees"] = append(petFieldsError.Errors["Fees"], err.Error())
+			// Do not increment error count because it is consider as non fields error
+			err = fmt.Errorf("%s: must have at least one entry for the fees", pet.Name)
+			petNonFieldsErrors = append(petNonFieldsErrors, err.Error())
 		}
 
 		// ---------------------------------------------------
@@ -833,9 +834,9 @@ func validateVehicleBizLogic(ctx context.Context, a *rlib.RAFlowJSONData, g *Val
 		// There must be one entry for the Fees
 		// ----------- Check for rule no 3 ------------
 		if !(len(vehicle.Fees) > 0) {
-			err = fmt.Errorf("must be at least one entry for the fees")
-			vehicleFieldsError.Total++
-			vehicleFieldsError.Errors["Fees"] = append(vehicleFieldsError.Errors["Fees"], err.Error())
+			// Do not increment error count because it is consider as non fields error
+			err = fmt.Errorf("%d %s %s: must have at least one entry for the fees", vehicle.VehicleYear, vehicle.VehicleMake, vehicle.VehicleModel)
+			vehicleNonFieldsErrors = append(vehicleNonFieldsErrors, err.Error())
 		}
 
 		// ---------------------------------------------------
@@ -891,9 +892,9 @@ func validateRentableBizLogic(ctx context.Context, a *rlib.RAFlowJSONData, g *Va
 		// There must be one entry for the Fees
 		// ----------- Check for rule no 2 ------------
 		if !(len(rentable.Fees) > 0) {
-			err = fmt.Errorf("must be at least one entry for the fees")
-			rentablesFieldsError.Total++
-			rentablesFieldsError.Errors["Fees"] = append(rentablesFieldsError.Errors["Fees"], err.Error())
+			// Do not increment error count because it is consider as non fields error
+			err = fmt.Errorf("%s: must have at least one entry for the fees", rentable.RentableName)
+			rentablesNonFieldsErrors = append(rentablesNonFieldsErrors, err.Error())
 		}
 
 		// Check if rentable is parent. If yes than increment parentRentableCount

--- a/rlib/bizprops.go
+++ b/rlib/bizprops.go
@@ -14,7 +14,6 @@ type BizPropsFee struct {
 	ARID             int64
 	ARName           string
 	Amount           float64
-	ARFLAGS          uint64
 	ARRentCycle      int64
 	ARProrationCycle int64
 }
@@ -80,7 +79,6 @@ func GetBizPropPetFees(ctx context.Context, BID int64, bizPropName string) (fees
 		pf.ARID = ar.ARID
 		pf.ARName = ar.Name
 		pf.Amount = ar.DefaultAmount
-		pf.ARFLAGS = ar.FLAGS
 		pf.ARRentCycle = ar.DefaultRentCycle
 		pf.ARProrationCycle = ar.DefaultProrationCycle
 
@@ -124,7 +122,6 @@ func GetBizPropVehicleFees(ctx context.Context, BID int64, bizPropName string) (
 		vf.ARID = ar.ARID
 		vf.ARName = ar.Name
 		vf.Amount = ar.DefaultAmount
-		vf.ARFLAGS = ar.FLAGS
 		vf.ARRentCycle = ar.DefaultRentCycle
 		vf.ARProrationCycle = ar.DefaultProrationCycle
 

--- a/rlib/raflow.go
+++ b/rlib/raflow.go
@@ -313,10 +313,7 @@ type RATiePeopleData struct {
 func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessage, flowPart string, flow *Flow) (err error) {
 	const funcname = "UpdateRAFlowJSON"
 	var (
-		raFlowData          RAFlowJSONData
-		modFlowPartData     = []byte(nil)
-		possessDatesChanged bool
-		rentDatesChanged    bool
+		raFlowData RAFlowJSONData
 	)
 	fmt.Printf("Entered in %s\n", funcname)
 
@@ -333,7 +330,6 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 	if err != nil {
 		return
 	}
-	meta := raFlowData.Meta
 
 	// JSON MARSHAL WITH ADDRESS
 	// REF: https://stackoverflow.com/questions/21390979/custom-marshaljson-never-gets-called-in-go
@@ -358,15 +354,25 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 			}
 
 			// ----- POSSESSION DATES CHANGED CHECK ----- //
-			if !((time.Time)(raFlowData.Dates.PossessionStart).Equal((time.Time)(a.PossessionStart)) &&
-				(time.Time)(raFlowData.Dates.PossessionStop).Equal((time.Time)(a.PossessionStop))) {
-				possessDatesChanged = true
+			newPStart := (time.Time)(a.PossessionStart)
+			newPStop := (time.Time)(a.PossessionStop)
+			if !((time.Time)(raFlowData.Dates.PossessionStart).Equal(newPStart) &&
+				(time.Time)(raFlowData.Dates.PossessionStop).Equal(newPStop)) {
+				possessDateChangeRAFlowUpdates(ctx, newPStart, newPStop, &raFlowData)
 			}
 
 			// ----- RENT DATES CHANGED CHECK ----- //
-			if !((time.Time)(raFlowData.Dates.RentStart).Equal((time.Time)(a.RentStart)) &&
-				(time.Time)(raFlowData.Dates.RentStop).Equal((time.Time)(a.RentStop))) {
-				rentDatesChanged = true
+			newRStart := (time.Time)(a.RentStart)
+			newRStop := (time.Time)(a.RentStop)
+			if !((time.Time)(raFlowData.Dates.RentStart).Equal(newRStart) &&
+				(time.Time)(raFlowData.Dates.RentStop).Equal(newRStop)) {
+				fmt.Println("********************************")
+				fmt.Println("Entered in rent date changes...")
+				fmt.Println("********************************")
+				err = rentDateChangeRAFlowUpdates(ctx, BID, newRStart, newRStop, &raFlowData)
+				if err != nil {
+					return
+				}
 			}
 
 		} else {
@@ -384,10 +390,7 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.Dates = a
 
 	case PeopleRAFlowPart:
 		a := []RAPeopleFlowData{}
@@ -402,8 +405,8 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 			// IF NOT TMPTCID THEN ASSIGN IT
 			for i := range a {
 				if a[i].TMPTCID == 0 {
-					meta.LastTMPTCID++
-					a[i].TMPTCID = meta.LastTMPTCID
+					raFlowData.Meta.LastTMPTCID++
+					a[i].TMPTCID = raFlowData.Meta.LastTMPTCID
 				}
 
 				// if Special needs are none, then it should indicate none
@@ -415,10 +418,7 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.People = a
 
 	case PetsRAFlowPart:
 		a := []RAPetsFlowData{}
@@ -439,28 +439,25 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 				}
 
 				if a[i].TMPPETID == 0 {
-					meta.LastTMPPETID++
-					a[i].TMPPETID = meta.LastTMPPETID
+					raFlowData.Meta.LastTMPPETID++
+					a[i].TMPPETID = raFlowData.Meta.LastTMPPETID
 
 					// IF NOT TMPASMID IN EACH FEE THEN
 					for j := range a[i].Fees {
 						if a[i].Fees[j].TMPASMID == 0 {
-							meta.LastTMPASMID++
-							a[i].Fees[j].TMPASMID = meta.LastTMPASMID
+							raFlowData.Meta.LastTMPASMID++
+							a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
 						}
 					}
 				}
 			}
 
 			// HAVEPETS  - BASED ON PET LIST LENGTH
-			meta.HavePets = len(a) > 0
+			raFlowData.Meta.HavePets = len(a) > 0
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.Pets = a
 
 	case VehiclesRAFlowPart:
 		a := []RAVehiclesFlowData{}
@@ -481,28 +478,25 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 				}
 
 				if a[i].TMPVID == 0 {
-					meta.LastTMPVID++
-					a[i].TMPVID = meta.LastTMPVID
+					raFlowData.Meta.LastTMPVID++
+					a[i].TMPVID = raFlowData.Meta.LastTMPVID
 
 					// IF NOT TMPASMID IN EACH FEE
 					for j := range a[i].Fees {
 						if a[i].Fees[j].TMPASMID == 0 {
-							meta.LastTMPASMID++
-							a[i].Fees[j].TMPASMID = meta.LastTMPASMID
+							raFlowData.Meta.LastTMPASMID++
+							a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
 						}
 					}
 				}
 			}
 
 			// HAVE VEHICLES - BASED ON VEHICLE LIST LENGTH
-			meta.HaveVehicles = len(a) > 0
+			raFlowData.Meta.HaveVehicles = len(a) > 0
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.Vehicles = a
 
 	case RentablesRAFlowPart:
 		a := []RARentablesFlowData{}
@@ -525,8 +519,8 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 				// IF NOT TMPASMID IN EACH FEE THEN
 				for j := range a[i].Fees {
 					if a[i].Fees[j].TMPASMID == 0 {
-						meta.LastTMPASMID++
-						a[i].Fees[j].TMPASMID = meta.LastTMPASMID
+						raFlowData.Meta.LastTMPASMID++
+						a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
 					}
 				}
 
@@ -534,10 +528,7 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.Rentables = a
 
 	case ParentChildRAFlowPart:
 		a := []RAParentChildFlowData{}
@@ -551,10 +542,7 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.ParentChild = a
 
 	case TieRAFlowPart:
 		a := RATieFlowData{}
@@ -573,49 +561,27 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		}
 
 		// MODIFIED PART DATA
-		modFlowPartData, err = json.Marshal(&a)
-		if err != nil {
-			return
-		}
+		raFlowData.Tie = a
 
 	default:
 		err = fmt.Errorf("unrecognized part type in RA flow: %s", flowPart)
 		return
 	}
 
-	// NOW UPDATE THE JSON FOR GIVEN FLOW PART
-	err = UpdateFlowData(ctx, flowPart, modFlowPartData, flow)
+	// GET JSON DATA FROM THE STRUCT
+	var modFlowData []byte
+	modFlowData, err = json.Marshal(&raFlowData)
 	if err != nil {
 		return
 	}
 
-	// IF MODIFIED META IS NOT EQUAL TO FLOW META THEN ONLY UPDATE META JSON
-	if !reflect.DeepEqual(meta, raFlowData.Meta) {
-		var modMetaInfo []byte
-		modMetaInfo, err = json.Marshal(&meta)
-		if err != nil {
-			return
-		}
-		err = UpdateFlowData(ctx, "meta", modMetaInfo, flow)
-		if err != nil {
-			return
-		}
-	}
+	// ASSIGN MODIFIED DATA
+	flow.Data = modFlowData
 
-	// IF POSSESSION DATES WERE CHANGED THEN TAKE NECESSARY ACTION
-	if possessDatesChanged {
-		err = possessDateChangeRAFlowUpdates(ctx, flow.FlowID)
-		if err != nil {
-			return
-		}
-	}
-
-	// IF RENT DATES WERE CHANGED THEN TAKE NECESSARY ACTION
-	if rentDatesChanged {
-		err = rentDateChangeRAFlowUpdates(ctx, flow.FlowID)
-		if err != nil {
-			return
-		}
+	// NOW UPDATE THE JSON FOR GIVEN FLOW PART
+	err = UpdateFlow(ctx, flow)
+	if err != nil {
+		return
 	}
 
 	return
@@ -623,88 +589,157 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 
 // possessDateChangeRAFlowUpdates updates raflow json with required
 // modification if possession dates are changed
-func possessDateChangeRAFlowUpdates(ctx context.Context, flowID int64) (err error) {
+func possessDateChangeRAFlowUpdates(ctx context.Context, pStart, pStop time.Time, raFlowData *RAFlowJSONData) {
 
-	// ----- GET THE UPDATED FLOW ----- //
-	var flow Flow
-	flow, err = GetFlow(ctx, flowID)
-	if err != nil {
-		return
-	}
-	if flow.FlowID == 0 {
-		err = fmt.Errorf("given flow with ID (%d) doesn't exist", flowID)
-		return
-	}
+	start := JSONDate(pStart)
+	stop := JSONDate(pStop)
 
-	// ----- GET THE RAFLOW DATA FROM FLOW ------ //
-	var raFlowData RAFlowJSONData
-	err = json.Unmarshal(flow.Data, &raFlowData)
-	if err != nil {
-		return
+	// ----- UPDATE PETS DTSTART/DTSTOP WITH NEW DATES ----- //
+	for i := range raFlowData.Pets {
+		raFlowData.Pets[i].DtStart = start
+		raFlowData.Pets[i].DtStop = stop
 	}
 
 	// ----- UPDATE PETS DTSTART/DTSTOP WITH NEW DATES ----- //
-	pets := raFlowData.Pets
-	for i := range pets {
-		pets[i].DtStart = raFlowData.Dates.PossessionStart
-		pets[i].DtStop = raFlowData.Dates.PossessionStop
+	for i := range raFlowData.Vehicles {
+		raFlowData.Vehicles[i].DtStart = start
+		raFlowData.Vehicles[i].DtStop = stop
 	}
-
-	var modPetsData []byte
-	modPetsData, err = json.Marshal(&pets)
-	if err != nil {
-		return
-	}
-	err = UpdateFlowData(ctx, "pets", modPetsData, &flow)
-	if err != nil {
-		return
-	}
-
-	// ----- UPDATE PETS DTSTART/DTSTOP WITH NEW DATES ----- //
-	vehicles := raFlowData.Vehicles
-	for i := range vehicles {
-		vehicles[i].DtStart = raFlowData.Dates.PossessionStart
-		vehicles[i].DtStop = raFlowData.Dates.PossessionStop
-	}
-
-	var modVehiclesData []byte
-	modVehiclesData, err = json.Marshal(&vehicles)
-	if err != nil {
-		return
-	}
-	err = UpdateFlowData(ctx, "vehicles", modVehiclesData, &flow)
-	if err != nil {
-		return
-	}
-
-	return
 }
 
 // rentDateChangeRAFlowUpdates updates raflow json with required
 // modification if rent dates are changed
-func rentDateChangeRAFlowUpdates(ctx context.Context, flowID int64) (err error) {
+func rentDateChangeRAFlowUpdates(ctx context.Context, BID int64, rStart, rStop time.Time, raFlowData *RAFlowJSONData) (err error) {
 
-	// ----- GET THE UPDATED FLOW ----- //
-	var flow Flow
-	flow, err = GetFlow(ctx, flowID)
-	if err != nil {
-		return
-	}
-	if flow.FlowID == 0 {
-		err = fmt.Errorf("given flow with ID (%d) doesn't exist", flowID)
-		return
+	const (
+		bizPropName = "general"
+	)
+
+	// -----------------------------------------------
+	// PET FEES MODIFICATION
+	// -----------------------------------------------
+	// LOOP OVER PET FEES IN RAFLOW
+	for pi := range raFlowData.Pets {
+
+		// GET FEES COPY
+		fees := []RAFeesData{}
+
+		// REMOVE PRORATED FEES FROM THE LIST
+		for i := range raFlowData.Pets[pi].Fees {
+			var ar AR
+			ar, err = GetAR(ctx, raFlowData.Pets[pi].Fees[i].ARID)
+			if err != nil {
+				return
+			}
+
+			// IF NOT (RENT ASM && START == STOP) THEN APPEND
+			if !(ar.FLAGS&(1<<4) != 0 &&
+				(time.Time)(raFlowData.Pets[pi].Fees[i].Start).Equal((time.Time)(raFlowData.Pets[pi].Fees[i].Stop))) {
+				fees = append(fees, raFlowData.Pets[pi].Fees[i])
+			}
+		}
+
+		// GET MODIFIED PET FEES FROM THIS FLOW DATA PET FEES AND RENT DATES
+		var modPetFees []RAFeesData
+		modPetFees, err = GetCalculatedFeesFromBaseFees(ctx, BID, bizPropName, rStart, rStop, fees)
+		if err != nil {
+			return
+		}
+
+		// UPDATE LASTASMID FOR EACH FEE
+		for i := range modPetFees {
+			raFlowData.Meta.LastTMPASMID++
+			modPetFees[i].TMPASMID = raFlowData.Meta.LastTMPASMID
+		}
+
+		// RE-ASSIGN FEES
+		raFlowData.Pets[pi].Fees = modPetFees
 	}
 
-	// ----- GET THE RAFLOW DATA FROM FLOW ------ //
-	var raFlowData RAFlowJSONData
-	err = json.Unmarshal(flow.Data, &raFlowData)
-	if err != nil {
-		return
+	// -----------------------------------------------
+	// VEHICLE FEES MODIFICATION
+	// -----------------------------------------------
+	// LOOP OVER VEHICLE FEES IN RAFLOW
+	for pi := range raFlowData.Vehicles {
+
+		// GET FEES COPY
+		fees := []RAFeesData{}
+
+		// REMOVE PRORATED FEES FROM THE LIST
+		for i := range raFlowData.Vehicles[pi].Fees {
+			var ar AR
+			ar, err = GetAR(ctx, raFlowData.Vehicles[pi].Fees[i].ARID)
+			if err != nil {
+				return
+			}
+
+			// IF NOT (RENT ASM && START == STOP) THEN APPEND
+			if !(ar.FLAGS&(1<<4) != 0 &&
+				(time.Time)(raFlowData.Vehicles[pi].Fees[i].Start).Equal((time.Time)(raFlowData.Vehicles[pi].Fees[i].Stop))) {
+				fees = append(fees, raFlowData.Vehicles[pi].Fees[i])
+			}
+		}
+
+		// GET MODIFIED VEHICLE FEES FROM THIS FLOW DATA VEHICLE FEES AND RENT DATES
+		var modVehicleFees []RAFeesData
+		modVehicleFees, err = GetCalculatedFeesFromBaseFees(ctx, BID, bizPropName, rStart, rStop, fees)
+		if err != nil {
+			return
+		}
+
+		// UPDATE LASTASMID FOR EACH FEE
+		for i := range modVehicleFees {
+			raFlowData.Meta.LastTMPASMID++
+			modVehicleFees[i].TMPASMID = raFlowData.Meta.LastTMPASMID
+		}
+
+		// RE-ASSIGN FEES
+		raFlowData.Vehicles[pi].Fees = modVehicleFees
 	}
 
-	// IMPLEMENTATION ERROR //
-	// TODO(Sudip): re-calculate fees for pets, vehicles, rentables
-	return /*fmt.Errorf("implementation error")*/
+	// -----------------------------------------------
+	// RENTABLE FEES MODIFICATION
+	// -----------------------------------------------
+	// LOOP OVER RENTABLE FEES IN RAFLOW
+	for pi := range raFlowData.Rentables {
+
+		// GET FEES COPY
+		fees := []RAFeesData{}
+
+		// REMOVE PRORATED FEES FROM THE LIST
+		for i := range raFlowData.Rentables[pi].Fees {
+			var ar AR
+			ar, err = GetAR(ctx, raFlowData.Rentables[pi].Fees[i].ARID)
+			if err != nil {
+				return
+			}
+
+			// IF NOT (RENT ASM && START == STOP) THEN APPEND
+			// i.e, NOT (PRORATED ONE)
+			if !(ar.FLAGS&(1<<4) != 0 &&
+				(time.Time)(raFlowData.Rentables[pi].Fees[i].Start).Equal((time.Time)(raFlowData.Rentables[pi].Fees[i].Stop))) {
+				fees = append(fees, raFlowData.Rentables[pi].Fees[i])
+			}
+		}
+
+		// GET MODIFIED RENTABLE FEES FROM THIS FLOW DATA RENTABLE FEES AND RENT DATES
+		var modRentableFees []RAFeesData
+		modRentableFees, err = GetCalculatedFeesFromBaseFees(ctx, BID, bizPropName, rStart, rStop, fees)
+		if err != nil {
+			return
+		}
+
+		// UPDATE LASTASMID FOR EACH FEE
+		for i := range modRentableFees {
+			raFlowData.Meta.LastTMPASMID++
+			modRentableFees[i].TMPASMID = raFlowData.Meta.LastTMPASMID
+		}
+
+		// RE-ASSIGN FEES
+		raFlowData.Rentables[pi].Fees = modRentableFees
+	}
+
+	return
 }
 
 // InsertInitialRAFlow writes a bunch of flow's sections record for a particular RA

--- a/rlib/raflow.go
+++ b/rlib/raflow.go
@@ -366,9 +366,6 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 			newRStop := (time.Time)(a.RentStop)
 			if !((time.Time)(raFlowData.Dates.RentStart).Equal(newRStart) &&
 				(time.Time)(raFlowData.Dates.RentStop).Equal(newRStop)) {
-				fmt.Println("********************************")
-				fmt.Println("Entered in rent date changes...")
-				fmt.Println("********************************")
 				err = rentDateChangeRAFlowUpdates(ctx, BID, newRStart, newRStop, &raFlowData)
 				if err != nil {
 					return
@@ -433,21 +430,21 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 			// IF NOT TMPPETID THEN ASSIGN IT
 			for i := range a {
 
+				if a[i].TMPPETID == 0 {
+					raFlowData.Meta.LastTMPPETID++
+					a[i].TMPPETID = raFlowData.Meta.LastTMPPETID
+				}
+
 				// IF NOT FEES LIST THEN
 				if len(a[i].Fees) == 0 {
 					a[i].Fees = []RAFeesData{}
 				}
 
-				if a[i].TMPPETID == 0 {
-					raFlowData.Meta.LastTMPPETID++
-					a[i].TMPPETID = raFlowData.Meta.LastTMPPETID
-
-					// IF NOT TMPASMID IN EACH FEE THEN
-					for j := range a[i].Fees {
-						if a[i].Fees[j].TMPASMID == 0 {
-							raFlowData.Meta.LastTMPASMID++
-							a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
-						}
+				// IF NOT TMPASMID IN EACH FEE THEN
+				for j := range a[i].Fees {
+					if a[i].Fees[j].TMPASMID == 0 {
+						raFlowData.Meta.LastTMPASMID++
+						a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
 					}
 				}
 			}
@@ -472,21 +469,21 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 			// IF NOT TMPPETID THEN
 			for i := range a {
 
+				if a[i].TMPVID == 0 {
+					raFlowData.Meta.LastTMPVID++
+					a[i].TMPVID = raFlowData.Meta.LastTMPVID
+				}
+
 				// IF NOT FEES ASSOCIATED
 				if len(a[i].Fees) == 0 {
 					a[i].Fees = []RAFeesData{}
 				}
 
-				if a[i].TMPVID == 0 {
-					raFlowData.Meta.LastTMPVID++
-					a[i].TMPVID = raFlowData.Meta.LastTMPVID
-
-					// IF NOT TMPASMID IN EACH FEE
-					for j := range a[i].Fees {
-						if a[i].Fees[j].TMPASMID == 0 {
-							raFlowData.Meta.LastTMPASMID++
-							a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
-						}
+				// IF NOT TMPASMID IN EACH FEE
+				for j := range a[i].Fees {
+					if a[i].Fees[j].TMPASMID == 0 {
+						raFlowData.Meta.LastTMPASMID++
+						a[i].Fees[j].TMPASMID = raFlowData.Meta.LastTMPASMID
 					}
 				}
 			}
@@ -575,16 +572,11 @@ func UpdateRAFlowJSON(ctx context.Context, BID int64, dataToUpdate json.RawMessa
 		return
 	}
 
-	// ASSIGN MODIFIED DATA
+	// ASSIGN JSON MARSHALLED MODIFIED DATA
 	flow.Data = modFlowData
 
-	// NOW UPDATE THE JSON FOR GIVEN FLOW PART
-	err = UpdateFlow(ctx, flow)
-	if err != nil {
-		return
-	}
-
-	return
+	// NOW UPDATE THE WHOLE FLOW
+	return UpdateFlow(ctx, flow)
 }
 
 // possessDateChangeRAFlowUpdates updates raflow json with required

--- a/rlib/raflow_fees.go
+++ b/rlib/raflow_fees.go
@@ -36,114 +36,30 @@ func GetRAFlowInitialPetFees(ctx context.Context,
 	fees = []RAFeesData{}
 
 	// GET PET FEES FROM BUSINESS PROPERTIES
-	var petFees []BizPropsFee
-	petFees, err = GetBizPropPetFees(ctx, BID, bizPropName)
+	var petBizFees []BizPropsFee
+	petBizFees, err = GetBizPropPetFees(ctx, BID, bizPropName)
 	if err != nil {
 		return
 	}
 
-	// FOR EACH FEE CONFIGURED IN BIZPROP
-	for _, petFee := range petFees {
+	// PREPARE THE PET BASE FEES FROM BIZ FEES
+	var petFees = []RAFeesData{}
+	for i := range petBizFees {
+		raFee := RAFeesData{ContractAmount: petBizFees[i].Amount}
+		MigrateStructVals(&petBizFees[i], &raFee)
+		petFees = append(petFees, raFee)
+	}
 
-		// GET RENT, PRORATION CYCLE
-		RentCycle := petFee.ARRentCycle
-		ProrationCycle := petFee.ARProrationCycle
+	// GET CALCULATED FEES FROM THIS BIZ CONIGURED FEES
+	fees, err = GetCalculatedFeesFromBaseFees(ctx, BID, bizPropName, rStart, rStop, petFees)
+	if err != nil {
+		return
+	}
 
-		// ========================================================================
-		// GET EPOCH BASED ON RENTCYCLE FOR THIS PET FEE
-		// ========================================================================
-		// TODO(Sudip & Steve): WHEN WE INTEGRATE EPOCHS IN RENTABLE TYPES       //
-		//                      WE SHOULD TAKE EPOCHS FIRST FROM IT THEN         //
-		//                      FROM BIZPROPS IN CASE NOT FOUND IN RENTALBE TYPE //
-		// ========================================================================
-		var epoch time.Time
-		_, epoch, err = GetEpochByBizPropName(ctx, BID, bizPropName, rStart, rStop, RentCycle)
-		if err != nil {
-			return
-		}
-
-		//--------------------------------------------------------------
-		// Here are the AR.FLAGS bits:
-		//
-		//     1<<4 -  Is Rent Assessment
-		//     1<<6 -  Is non-recur charge
-		//     1<<7 -  PETID required
-		//--------------------------------------------------------------
-		// IF IT IS NON-RECUR CHARGE THEN
-		oneTimeCharge := (petFee.ARFLAGS & (1 << 6)) != 0
-		if oneTimeCharge {
-			// ADD FEE IN LIST
-			meta.LastTMPASMID++
-			raFee := RAFeesData{
-				TMPASMID:        meta.LastTMPASMID,
-				ASMID:           0,
-				ARID:            petFee.ARID,
-				ARName:          petFee.ARName,
-				ContractAmount:  petFee.Amount,
-				RentCycle:       RECURNONE,
-				Start:           JSONDate(rStart),
-				Stop:            JSONDate(rStart),
-				AtSigningPreTax: 0.00,
-				SalesTax:        0.00,
-				TransOccTax:     0.00,
-				Comment:         "",
-			}
-			fees = append(fees, raFee)
-
-		} else if petFee.ARFLAGS&(1<<4) != 0 { // IT MUST BE RENT ASM ONE
-
-			// CHECK FOR PRORATED AMOUNT REQUIRED
-			needProratedRent := rStart.Day() != epoch.Day()
-
-			// START DAY IS NOT SAME AS EPOCH THEN CALCULATE PRORATED AMOUNT
-			if needProratedRent {
-				td2 := time.Date(rStart.Year(), rStart.Month(), epoch.Day(), rStart.Hour(), rStart.Minute(), rStart.Second(), rStart.Nanosecond(), rStart.Location())
-				td2 = NextPeriod(&td2, RentCycle)
-
-				tot, np, tp := SimpleProrateAmount(petFee.Amount, RentCycle, ProrationCycle, &rStart, &td2, &epoch)
-				cmt := ""
-				if tot < petFee.Amount {
-					cmt = fmt.Sprintf("prorated for %d of %d %s", np, tp, ProrationUnits(ProrationCycle))
-				}
-
-				// ADD FEE IN LIST
-				meta.LastTMPASMID++
-				raFee := RAFeesData{
-					TMPASMID:        meta.LastTMPASMID,
-					ASMID:           0,
-					ARID:            petFee.ARID,
-					ARName:          petFee.ARName,
-					ContractAmount:  tot,
-					RentCycle:       RentCycle,
-					Start:           JSONDate(rStart),
-					Stop:            JSONDate(rStart),
-					AtSigningPreTax: 0.00,
-					SalesTax:        0.00,
-					TransOccTax:     0.00,
-					Comment:         cmt,
-				}
-				fees = append(fees, raFee)
-			}
-
-			// CALCULATE RECURRING ONE FROM EPOCH DATE
-			// ADD FEE IN LIST
-			meta.LastTMPASMID++
-			raFee := RAFeesData{
-				TMPASMID:        meta.LastTMPASMID,
-				ASMID:           0,
-				ARID:            petFee.ARID,
-				ARName:          petFee.ARName,
-				ContractAmount:  petFee.Amount,
-				RentCycle:       RentCycle,
-				Start:           JSONDate(epoch),
-				Stop:            JSONDate(rStop),
-				AtSigningPreTax: 0.00,
-				SalesTax:        0.00,
-				TransOccTax:     0.00,
-				Comment:         "",
-			}
-			fees = append(fees, raFee)
-		}
+	// UPDATE LASTASMID FOR EACH FEE
+	for i := range fees {
+		meta.LastTMPASMID++
+		fees[i].TMPASMID = meta.LastTMPASMID
 	}
 
 	return
@@ -179,21 +95,65 @@ func GetRAFlowInitialVehicleFees(ctx context.Context,
 	fees = []RAFeesData{}
 
 	// GET VEHICLE FEES FROM BUSINESS PROPERTIES
-	var vehicleFees []BizPropsFee
-	vehicleFees, err = GetBizPropVehicleFees(ctx, BID, bizPropName)
+	var vehicleBizFees []BizPropsFee
+	vehicleBizFees, err = GetBizPropVehicleFees(ctx, BID, bizPropName)
 	if err != nil {
 		return
 	}
 
-	// FOR EACH FEE CONFIGURED IN BIZPROP
-	for _, vehicleFee := range vehicleFees {
+	// PREPARE THE VEHICLE BASE FEES FROM BIZ FEES
+	var vehicleFees = []RAFeesData{}
+	for i := range vehicleBizFees {
+		raFee := RAFeesData{ContractAmount: vehicleBizFees[i].Amount}
+		MigrateStructVals(&vehicleBizFees[i], &raFee)
+		vehicleFees = append(vehicleFees, raFee)
+	}
+
+	// GET CALCULATED FEES FROM THIS BIZ CONIGURED FEES
+	fees, err = GetCalculatedFeesFromBaseFees(ctx, BID, bizPropName, rStart, rStop, vehicleFees)
+	if err != nil {
+		return
+	}
+
+	// UPDATE LASTASMID FOR EACH FEE
+	for i := range fees {
+		meta.LastTMPASMID++
+		fees[i].TMPASMID = meta.LastTMPASMID
+	}
+
+	return
+}
+
+// GetCalculatedFeesFromBaseFees get the actual calculate fees based on
+// given base fees list
+func GetCalculatedFeesFromBaseFees(ctx context.Context, BID int64, bizPropName string,
+	rStart, rStop time.Time,
+	baseFees []RAFeesData,
+) (fees []RAFeesData, err error) {
+
+	const funcname = "GetCalculatedFeesFromBaseFees"
+	fmt.Printf("Entered in %s\n", funcname)
+
+	// INITIALIZE FEES
+	fees = []RAFeesData{}
+
+	// FOR EACH FEE FROM BASE FEES
+	for _, baseFee := range baseFees {
+
+		// GET AR FROM ARID IN FEES
+		var ar AR
+		ar, err = GetAR(ctx, baseFee.ARID)
+		if err != nil {
+			return
+		}
 
 		// GET RENT, PRORATION CYCLE
-		RentCycle := vehicleFee.ARRentCycle
-		ProrationCycle := vehicleFee.ARProrationCycle
+		RentCycle := baseFee.RentCycle
+		// TODO(Sudip): IF PRORATIONCYCLE WILL BE ADDED IN FEES THEN TAKE THAT
+		ProrationCycle := ar.DefaultProrationCycle
 
 		// ========================================================================
-		// GET EPOCH BASED ON RENTCYCLE FOR THIS VEHICLE FEE
+		// GET EPOCH BASED ON RENTCYCLE FOR THIS BASE FEE
 		// ========================================================================
 		// TODO(Sudip & Steve): WHEN WE INTEGRATE EPOCHS IN RENTABLE TYPES       //
 		//                      WE SHOULD TAKE EPOCHS FIRST FROM IT THEN         //
@@ -213,16 +173,17 @@ func GetRAFlowInitialVehicleFees(ctx context.Context,
 		//     1<<8 -  VID required
 		//--------------------------------------------------------------
 		// IF IT IS NON-RECUR CHARGE THEN
-		oneTimeCharge := (vehicleFee.ARFLAGS & (1 << 6)) != 0
+		oneTimeCharge := (ar.FLAGS & (1 << 6)) != 0
+		rentAsmCharge := (ar.FLAGS & (1 << 4)) != 0
+
 		if oneTimeCharge {
 			// ADD FEE IN LIST
-			meta.LastTMPASMID++
 			raFee := RAFeesData{
-				TMPASMID:        meta.LastTMPASMID,
+				TMPASMID:        0,
 				ASMID:           0,
-				ARID:            vehicleFee.ARID,
-				ARName:          vehicleFee.ARName,
-				ContractAmount:  vehicleFee.Amount,
+				ARID:            baseFee.ARID,
+				ARName:          baseFee.ARName,
+				ContractAmount:  baseFee.ContractAmount,
 				RentCycle:       RECURNONE,
 				Start:           JSONDate(rStart),
 				Stop:            JSONDate(rStart),
@@ -233,7 +194,7 @@ func GetRAFlowInitialVehicleFees(ctx context.Context,
 			}
 			fees = append(fees, raFee)
 
-		} else if vehicleFee.ARFLAGS&(1<<4) != 0 { // IT MUST BE RENT ASM ONE
+		} else if rentAsmCharge { // IT MUST BE RENT ASM ONE
 
 			// CHECK FOR PRORATED AMOUNT REQUIRED
 			needProratedRent := rStart.Day() != epoch.Day()
@@ -243,21 +204,20 @@ func GetRAFlowInitialVehicleFees(ctx context.Context,
 				td2 := time.Date(rStart.Year(), rStart.Month(), epoch.Day(), rStart.Hour(), rStart.Minute(), rStart.Second(), rStart.Nanosecond(), rStart.Location())
 				td2 = NextPeriod(&td2, RentCycle)
 
-				tot, np, tp := SimpleProrateAmount(vehicleFee.Amount, RentCycle, ProrationCycle, &rStart, &td2, &epoch)
+				tot, np, tp := SimpleProrateAmount(baseFee.ContractAmount, RentCycle, ProrationCycle, &rStart, &td2, &epoch)
 				cmt := ""
-				if tot < vehicleFee.Amount {
+				if tot < baseFee.ContractAmount {
 					cmt = fmt.Sprintf("prorated for %d of %d %s", np, tp, ProrationUnits(ProrationCycle))
 				}
 
 				// ADD FEE IN LIST
-				meta.LastTMPASMID++
 				raFee := RAFeesData{
-					TMPASMID:        meta.LastTMPASMID,
+					TMPASMID:        0,
 					ASMID:           0,
-					ARID:            vehicleFee.ARID,
-					ARName:          vehicleFee.ARName,
+					ARID:            baseFee.ARID,
+					ARName:          baseFee.ARName,
 					ContractAmount:  tot,
-					RentCycle:       RentCycle,
+					RentCycle:       RECURNONE,
 					Start:           JSONDate(rStart),
 					Stop:            JSONDate(rStart),
 					AtSigningPreTax: 0.00,
@@ -270,13 +230,12 @@ func GetRAFlowInitialVehicleFees(ctx context.Context,
 
 			// CALCULATE RECURRING ONE FROM EPOCH DATE
 			// ADD FEE IN LIST
-			meta.LastTMPASMID++
 			raFee := RAFeesData{
-				TMPASMID:        meta.LastTMPASMID,
+				TMPASMID:        0,
 				ASMID:           0,
-				ARID:            vehicleFee.ARID,
-				ARName:          vehicleFee.ARName,
-				ContractAmount:  vehicleFee.Amount,
+				ARID:            baseFee.ARID,
+				ARName:          baseFee.ARName,
+				ContractAmount:  baseFee.ContractAmount,
 				RentCycle:       RentCycle,
 				Start:           JSONDate(epoch),
 				Stop:            JSONDate(rStop),

--- a/rlib/update.go
+++ b/rlib/update.go
@@ -364,6 +364,11 @@ func UpdateFlow(ctx context.Context, a *Flow) error {
 		a.LastModBy = sess.UID
 	}
 
+	// make sure that json is valid before inserting it in database
+	if !(IsByteDataValidJSON(a.Data)) {
+		return ErrFlowInvalidJSONData
+	}
+
 	fields := []interface{}{a.BID, a.UserRefNo, a.FlowType, a.ID, []byte(a.Data), a.LastModBy, a.FlowID}
 	if tx, ok := DBTxFromContext(ctx); ok { // if transaction is supplied
 		stmt := tx.Stmt(RRdb.Prepstmt.UpdateFlow)

--- a/rlib/update.go
+++ b/rlib/update.go
@@ -364,7 +364,7 @@ func UpdateFlow(ctx context.Context, a *Flow) error {
 		a.LastModBy = sess.UID
 	}
 
-	fields := []interface{}{a.BID, a.UserRefNo, a.FlowType, a.ID, a.Data, a.LastModBy, a.FlowID}
+	fields := []interface{}{a.BID, a.UserRefNo, a.FlowType, a.ID, []byte(a.Data), a.LastModBy, a.FlowID}
 	if tx, ok := DBTxFromContext(ctx); ok { // if transaction is supplied
 		stmt := tx.Stmt(RRdb.Prepstmt.UpdateFlow)
 		defer stmt.Close()

--- a/webclient/html/raflow/raflow.css
+++ b/webclient/html/raflow/raflow.css
@@ -127,6 +127,16 @@
     */
 }
 
+.tab-error-dot {
+    background: #f44336;
+    border-radius: 50%;
+    height: 8px;
+    width: 8px;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+}
+
 #progressbar #steps-list li a div.error-true {
     display: initial;
 }

--- a/webclient/js/elems/datetimeutil.js
+++ b/webclient/js/elems/datetimeutil.js
@@ -291,6 +291,23 @@ window.w2uiDateControlString = function (dt) {
 };
 
 //-----------------------------------------------------------------------------
+// w2uiUTCDateControlString
+//           - return a UTC date string formatted the way the w2ui dates are
+//             expected, based on the supplied date that can be
+//             used as the .value attribute of a date control.  That is, in
+//             the format  m/d/yyyy.
+// @params
+//   dt = java date value
+// @return string value mm-dd-yyyy
+//-----------------------------------------------------------------------------
+window.w2uiUTCDateControlString = function (dt) {
+    var m = dt.getUTCMonth() + 1;
+    var d = dt.getUTCDate();
+    var s = '' + m + '/' + d+'/' + dt.getUTCFullYear();
+    return s;
+};
+
+//-----------------------------------------------------------------------------
 // w2uiDateTimeControlString
 //           - return a datetime string formatted the way the w2ui datetimes
 //             are expected, based on the supplied date that can be

--- a/webclient/js/elems/raflow/fees.js
+++ b/webclient/js/elems/raflow/fees.js
@@ -332,6 +332,11 @@ window.GetFeeFormToolbar = function() {
 // -------------------------------------------------------------------------------
 window.FeeFormOnRefreshHandler = function(feeForm) {
 
+    // if RAID version then don't do anything
+    if (app.raflow.version == "raid") {
+        return;
+    }
+
     // -- ARID -- //
     var ARIDSel = {};
     feeForm.get("ARID").options.items.forEach(function(item) {

--- a/webclient/js/elems/raflow/fees.js
+++ b/webclient/js/elems/raflow/fees.js
@@ -74,7 +74,90 @@ window.GetFeeFormFields = function() {
 // GetFeeGridColumns - returns a clone of column definition list
 //                     required by any fees grid
 // -------------------------------------------------------------------------------
-window.GetFeeGridColumns = function() {
+window.GetFeeGridColumns = function(feesGrid) {
+
+    var haveErrorCol;
+    switch (feesGrid){
+        case 'RAPetFeesGrid':
+            haveErrorCol = {
+                field: 'haveError',
+                size: '30px',
+                hidden: false,
+                render: function (record) {
+                    var haveError = false;
+                    if (app.raflow.validationErrors.pets) {
+                        var pets = app.raflow.validationCheck.errors.pets;
+                        for (var i = 0; i < pets.length; i++) {
+                            for(var j = 0; j < pets[i].fees.length; j++){
+                                if(pets[i].fees[j].TMPASMID === record.TMPASMID){
+                                    haveError = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (haveError) {
+                        return '<i class="fas fa-exclamation-triangle" title="error"></i>';
+                    } else {
+                        return "";
+                    }
+                }
+            };
+            break;
+        case 'RAVehicleFeesGrid':
+            haveErrorCol = {
+                field: 'haveError',
+                size: '30px',
+                hidden: false,
+                render: function (record) {
+                    var haveError = false;
+                    if (app.raflow.validationErrors.vehicles) {
+                        var vehicles = app.raflow.validationCheck.errors.vehicles;
+                        for (var i = 0; i < vehicles.length; i++) {
+                            for(var j = 0; j < vehicles[i].fees.length; j++){
+                                if(vehicles[i].fees[j].TMPASMID === record.TMPASMID){
+                                    haveError = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (haveError) {
+                        return '<i class="fas fa-exclamation-triangle" title="error"></i>';
+                    } else {
+                        return "";
+                    }
+                }
+            };
+            break;
+        case 'RARentableFeesGrid':
+            haveErrorCol = {
+                field: 'haveError',
+                size: '30px',
+                hidden: false,
+                render: function (record) {
+                    var haveError = false;
+                    if (app.raflow.validationErrors.rentables) {
+                        var rentables = app.raflow.validationCheck.errors.rentables;
+                        for (var i = 0; i < rentables.length; i++) {
+                            for(var j = 0; j < rentables[i].fees.length; j++){
+                                if(rentables[i].fees[j].TMPASMID === record.TMPASMID){
+                                    haveError = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (haveError) {
+                        return '<i class="fas fa-exclamation-triangle" title="error"></i>';
+                    } else {
+                        return "";
+                    }
+                }
+            };
+            break;
+    }
+
     var columns = [
         {
             field: 'recid',
@@ -217,6 +300,8 @@ window.GetFeeGridColumns = function() {
             }
         }
     ];
+
+    columns.unshift(haveErrorCol);
 
     // RETURN the clone
     return $.extend(true, [], columns);

--- a/webclient/js/elems/raflow/final.js
+++ b/webclient/js/elems/raflow/final.js
@@ -52,7 +52,10 @@ window.BuildRAFinalRentablesFeesGrid = function() {
         },
         multiSelect: false,
         style: 'border: 2px solid silver; display: block; background-color: transparent;',
-        columns: gridCols
+        columns: gridCols,
+        onSelect: function (event) {
+            event.preventDefault(); // Prevent selection of row
+        }
     });
 };
 
@@ -92,11 +95,14 @@ window.BuildRAFinalPetsFeesGrid = function() {
         show: {
             toolbar:    false,
             header:     true,
-            footer:     false,
+            footer:     false
         },
         multiSelect: false,
         style: 'border: 2px solid silver; display: block;',
-        columns: gridCols
+        columns: gridCols,
+        onSelect: function (event) {
+            event.preventDefault(); // Prevent selection of row
+        }
     });
 };
 
@@ -136,11 +142,14 @@ window.BuildRAFinalVehiclesFeesGrid = function() {
         show: {
             toolbar:    false,
             header:     true,
-            footer:     false,
+            footer:     false
         },
         multiSelect: false,
         style: 'border: 2px solid silver; display: block;',
         columns: gridCols,
+        onSelect: function (event) {
+            event.preventDefault(); // Prevent selection of row
+        }
     });
 };
 

--- a/webclient/js/elems/raflow/people.js
+++ b/webclient/js/elems/raflow/people.js
@@ -383,6 +383,10 @@ window.loadRAPeopleForm = function () {
             },
             onRefresh: function (event) {
                 event.onComplete = function () {
+
+                    // Hide Save and Add Button
+                    $("button[name=saveadd]").addClass("hidden");
+
                     var form = this,
                         BID = getCurrentBID(),
                         BUD = getBUDfromBID(BID);

--- a/webclient/js/elems/raflow/people.js
+++ b/webclient/js/elems/raflow/people.js
@@ -12,7 +12,7 @@
     managePeopleW2UIItems, removeRAFlowPersonAJAX, saveRAFlowPersonAJAX, onCheckboxesChange, getRecIDFromTMPTCID, dispalyRAPeopleGridError,
     displayRAPeopleFormError, getPeopleIndex, displayFormFieldsError,
     GetCurrentFlowID, EnableDisableRAFlowVersionInputs, ShowHideGridToolbarAddButton,
-    HideAllSliderContent
+    HideAllSliderContent, displayRAPeopleFormTabErrorDot
 */
 
 "use strict";
@@ -248,6 +248,8 @@ window.loadRAPeopleForm = function () {
                                 form.refresh(); // need to refresh for form changes
 
                                 displayRAPeopleFormError();
+
+                                displayRAPeopleFormTabErrorDot();
                             }).fail(function (data) {
                                 form.message(data.message);
                             });
@@ -403,6 +405,9 @@ window.loadRAPeopleForm = function () {
 
                     // FREEZE THE INPUTS IF VERSION IS RAID
                     EnableDisableRAFlowVersionInputs(form);
+
+                    // Display error dot for the tabs
+                    displayRAPeopleFormTabErrorDot();
                 };
             },
             onValidate: function (event) {
@@ -935,4 +940,33 @@ window.getPeopleIndex = function (TMPTCID, people) {
     }
 
     return index;
+};
+
+// displayRAPeopleFormTabErrorDot
+window.displayRAPeopleFormTabErrorDot = function () {
+
+    // Basic Info tab
+    if ($(".w2ui-page.page-0").find(".error").length > 0){
+        $("#tabs_RATransactantForm_tabs_tab_tab1").css('position', 'relative');
+        $("#tabs_RATransactantForm_tabs_tab_tab1").append("<div class='tab-error-dot'></div>");
+    }
+
+    // Prospect tab
+    if ($(".w2ui-page.page-1").find(".error").length > 0){
+        $("#tabs_RATransactantForm_tabs_tab_tab4").css('position', 'relative');
+        $("#tabs_RATransactantForm_tabs_tab_tab4").append("<div class='tab-error-dot'></div>");
+    }
+
+    // Payor tab
+    if ($(".w2ui-page.page-2").find(".error").length > 0){
+        $("#tabs_RATransactantForm_tabs_tab_tab3").css('position', 'relative');
+        $("#tabs_RATransactantForm_tabs_tab_tab3").append("<div class='tab-error-dot'></div>");
+    }
+
+    // User tab
+    if ($(".w2ui-page.page-3").find(".error").length > 0){
+        $("#tabs_RATransactantForm_tabs_tab_tab2").css('position', 'relative');
+        $("#tabs_RATransactantForm_tabs_tab_tab2").append("<div class='tab-error-dot'></div>");
+    }
+
 };

--- a/webclient/js/elems/raflow/pets.js
+++ b/webclient/js/elems/raflow/pets.js
@@ -586,7 +586,7 @@ window.loadRAPetsGrid = function () {
             },
             multiSelect: false,
             style: 'border: 1px solid silver;',
-            columns: GetFeeGridColumns(),
+            columns: GetFeeGridColumns('RAPetFeesGrid'),
             onClick: function(event) {
                 event.onComplete = function() {
                     var yes_args = [this, event.recid],

--- a/webclient/js/elems/raflow/pets.js
+++ b/webclient/js/elems/raflow/pets.js
@@ -843,9 +843,6 @@ window.loadRAPetsGrid = function () {
                 var feeForm = this;
                 event.onComplete = function() {
 
-                    // minimum actions need to be taken care in refres event for fee form
-                    FeeFormOnRefreshHandler(feeForm);
-
                     // there is NO PETID actually, so have to work around with recid key
                     formRefreshCallBack(feeForm);
 
@@ -868,6 +865,9 @@ window.loadRAPetsGrid = function () {
 
                     // FREEZE THE INPUTS IF VERSION IS RAID
                     EnableDisableRAFlowVersionInputs(feeForm);
+
+                    // minimum actions need to be taken care in refres event for fee form
+                    FeeFormOnRefreshHandler(feeForm);
                 };
             }
         });

--- a/webclient/js/elems/raflow/raactions.js
+++ b/webclient/js/elems/raflow/raactions.js
@@ -12,7 +12,8 @@
     GetCurrentFlowID, CloseRAFlowLayout,
     ChangeRAFlowVersionToolbar,
     displayErrorDot,
-    displayActiveComponentError
+    displayActiveComponentError,
+    w2uiUTCDateControlString
 */
 "use strict";
 
@@ -201,6 +202,12 @@ window.reloadActionForm = function() {
             $('#NoticeToMoveRow')[0].style.display = '';  //'none';
             $('#TerminateRow')[0].style.display = '';  //'none';
 
+            // auto load date in component if it is present in meta
+            if (data.meta.DocumentDate != "1900-01-01 00:00:00 UTC"){
+                var documentDate = w2uiUTCDateControlString(new Date(data.meta.DocumentDate));
+                w2ui.RAActionForm.record.RADocumentDate = documentDate;
+            }
+
             w2ui.RAActionForm.get('RADocumentDate').hidden = false;
             $('button[name=RAGenerateRAForm]').show();
             $('button[name=RAGenerateMoveInInspectionForm]').show();
@@ -348,7 +355,11 @@ window.refreshLabels = function () {
         if (meta.NoticeToMoveUID == 0) {
             x.innerHTML = '';
         } else {
-            x.innerHTML = dtFormatISOToW2ui(meta.NoticeToMoveReported) + ' by ' + meta.NoticeToMoveName + ' (move date: ' + dtFormatISOToW2ui(meta.NoticeToMoveDate) + ')';
+            var moveDate = '';
+            if (meta.NoticeToMoveDate != "1900-01-01 00:00:00 UTC") {
+                moveDate = w2uiUTCDateControlString(new Date(meta.NoticeToMoveDate));
+            }
+            x.innerHTML = dtFormatISOToW2ui(meta.NoticeToMoveReported) + ' by ' + meta.NoticeToMoveName + ' (move date: ' + moveDate + ')';
         }
     }
 
@@ -423,7 +434,7 @@ window.refreshLabels = function () {
     x = document.getElementById("bannerMoveDate");
     if (x !== null) {
         if (meta.NoticeToMoveDate != "1900-01-01 00:00:00 UTC") {
-            x.innerHTML = dtFormatISOToW2ui(meta.NoticeToMoveDate);
+            x.innerHTML = w2uiUTCDateControlString(new Date(meta.NoticeToMoveDate));
         } else {
             x.innerHTML = '';
         }
@@ -442,7 +453,7 @@ window.refreshLabels = function () {
     x = document.getElementById("bannerDocumentDate");
     if (x !== null) {
         if (meta.DocumentDate != "1900-01-01 00:00:00 UTC") {
-            x.innerHTML = dtFormatISOToW2ui(meta.DocumentDate);
+            x.innerHTML = w2uiUTCDateControlString(new Date(meta.DocumentDate));
         } else {
             x.innerHTML = '';
         }
@@ -675,6 +686,12 @@ window.loadRAActionForm = function() {
                             case 5: // Received Notice-To-Move
                                 w2ui.RAActionForm.get('RANoticeToMoveDate').hidden = false;
 
+                                // auto load date in component if it is present in meta
+                                if (app.raflow.Flow.Data.meta.NoticeToMoveDate != "1900-01-01 00:00:00 UTC"){
+                                    var moveDate = w2uiUTCDateControlString(new Date(app.raflow.Flow.Data.meta.NoticeToMoveDate));
+                                    this.record.RANoticeToMoveDate = moveDate;
+                                }
+
                                 w2ui.RAActionForm.get('RATerminationReason').hidden = true;
                                 delete this.record.RATerminationReason;
                                 $('button[name=updateAction]').attr('disabled',false);
@@ -684,6 +701,7 @@ window.loadRAActionForm = function() {
                                 w2ui.RAActionForm.get('RATerminationReason').hidden = false;
                                 $('button[name=updateAction]').attr('disabled',true);
 
+                                delete this.record.RANoticeToMoveDate;
                                 w2ui.RAActionForm.get('RANoticeToMoveDate').hidden = true;
                                 break;
 
@@ -692,7 +710,7 @@ window.loadRAActionForm = function() {
                                 delete this.record.RATerminationReason;
                                 $('button[name=updateAction]').attr('disabled',false);
 
-
+                                delete this.record.RANoticeToMoveDate;
                                 w2ui.RAActionForm.get('RANoticeToMoveDate').hidden = true;
                         }
                         break;

--- a/webclient/js/elems/raflow/rentables.js
+++ b/webclient/js/elems/raflow/rentables.js
@@ -346,14 +346,14 @@ window.loadRARentablesGrid = function () {
                 toolbarReload:  false,
                 toolbarInput:   false,
                 toolbarColumns: false,
-                footer:         false,
+                footer:         false
             },
             style: 'border: 2px solid white; display: block;',
-            columns: GetFeeGridColumns(),
+            columns: GetFeeGridColumns('RARentableFeesGrid'),
             toolbar: {
                 items: [
                     {id: 'bt3', type: 'spacer'},
-                    {id: 'btnClose', type: 'button', icon: 'fas fa-times'},
+                    {id: 'btnClose', type: 'button', icon: 'fas fa-times'}
                 ],
                 onClick: function (event) {
                     switch(event.target) {

--- a/webclient/js/elems/raflow/rentables.js
+++ b/webclient/js/elems/raflow/rentables.js
@@ -624,9 +624,6 @@ window.loadRARentablesGrid = function () {
                 var feeForm = this;
                 event.onComplete = function() {
 
-                    // minimum actions need to be taken care in refres event for fee form
-                    FeeFormOnRefreshHandler(feeForm);
-
                     // there is NO PETID actually, so have to work around with recid key
                     formRefreshCallBack(feeForm);
 
@@ -644,6 +641,9 @@ window.loadRARentablesGrid = function () {
 
                     // FREEZE THE INPUTS IF VERSION IS RAID
                     EnableDisableRAFlowVersionInputs(feeForm);
+
+                    // minimum actions need to be taken care in refres event for fee form
+                    FeeFormOnRefreshHandler(feeForm);
                 };
             }
         });

--- a/webclient/js/elems/raflow/vehicles.js
+++ b/webclient/js/elems/raflow/vehicles.js
@@ -630,7 +630,7 @@ window.loadRAVehiclesGrid = function () {
             },
             multiSelect: false,
             style: 'border: 1px solid silver;',
-            columns: GetFeeGridColumns(),
+            columns: GetFeeGridColumns('RAVehicleFeesGrid'),
             onClick: function(event) {
                 event.onComplete = function() {
                     var yes_args = [this, event.recid],
@@ -1216,7 +1216,7 @@ window.displayRAVehicleFeesGridError = function () {
     }
 
     if (app.raflow.validationErrors.vehicles) {
-        var vehicles = app.raflow.validationCheck.errors.vehicle;
+        var vehicles = app.raflow.validationCheck.errors.vehicles;
         for (i = 0; i < vehicles.length; i++) {
             for (var j = 0; j < vehicles[i].fees.length; j++) {
                 if (vehicles[i].fees[j].total > 0) {
@@ -1253,7 +1253,7 @@ window.displayRAVehicleFormError = function(){
     var record = form.record;
 
     // get list of pets
-    var vehicles = app.raflow.validationCheck.errors.vehicle;
+    var vehicles = app.raflow.validationCheck.errors.vehicles;
 
     // get index of pet for whom form is opened
     var index = getVehicleIndex(record.TMPVID, vehicles);

--- a/webclient/js/elems/raflow/vehicles.js
+++ b/webclient/js/elems/raflow/vehicles.js
@@ -886,9 +886,6 @@ window.loadRAVehiclesGrid = function () {
                 var feeForm = this;
                 event.onComplete = function() {
 
-                    // minimum actions need to be taken care in refres event for fee form
-                    FeeFormOnRefreshHandler(feeForm);
-
                     // there is NO VID actually, so have to work around with recid key
                     formRefreshCallBack(feeForm);
 
@@ -911,6 +908,9 @@ window.loadRAVehiclesGrid = function () {
 
                     // FREEZE THE INPUTS IF VERSION IS RAID
                     EnableDisableRAFlowVersionInputs(feeForm);
+
+                    // minimum actions need to be taken care in refres event for fee form
+                    FeeFormOnRefreshHandler(feeForm);
                 };
             }
         });

--- a/ws/raflow_actions.go
+++ b/ws/raflow_actions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"rentroll/bizlogic"
 	"rentroll/rlib"
 	"time"
 )
@@ -99,25 +100,44 @@ func SvcSetRAState(w http.ResponseWriter, r *http.Request, d *ServiceData) {
 		if err != nil {
 			return
 		}
+
+		// ------------------
+		// COMMIT TRANSACTION
+		// ------------------
+		if err = tx.Commit(); err != nil {
+			return
+		}
+
+		// -------------------
+		// WRITE FLOW RESPONSE
+		// -------------------
+		SvcWriteFlowResponse(ctx, d.BID, flow, w)
+		return
+
 	case "refno":
-		flow, err = handleRefNoVersion(ctx, d, foo, raFlowData)
+		var resp FlowResponse
+		var raflowRespData RAFlowResponse
+
+		raflowRespData, err = handleRefNoVersion(ctx, d, foo, raFlowData)
 		if err != nil {
 			return
 		}
+
+		// ------------------
+		// COMMIT TRANSACTION
+		// ------------------
+		if err = tx.Commit(); err != nil {
+			return
+		}
+
+		// -------------------
+		// WRITE FLOW RESPONSE
+		// -------------------
+		resp.Record = raflowRespData
+		resp.Status = "success"
+		SvcWriteResponse(d.BID, &resp, w)
 	}
 
-	// ------------------
-	// COMMIT TRANSACTION
-	// ------------------
-	if err = tx.Commit(); err != nil {
-		return
-	}
-
-	// -------------------
-	// WRITE FLOW RESPONSE
-	// -------------------
-	SvcWriteFlowResponse(ctx, d.BID, flow, w)
-	return
 }
 
 func handleRAIDVersion(ctx context.Context, d *ServiceData, foo RAActionDataRequest, raFlowData rlib.RAFlowJSONData) (rlib.Flow, error) {
@@ -369,7 +389,7 @@ func handleRAIDVersion(ctx context.Context, d *ServiceData, foo RAActionDataRequ
 	return flow, nil
 }
 
-func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataRequest, raFlowData rlib.RAFlowJSONData) (rlib.Flow, error) {
+func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataRequest, raFlowData rlib.RAFlowJSONData) (RAFlowResponse, error) {
 	UserRefNo := foo.UserRefNo
 	Action := foo.Action
 	Mode := foo.Mode
@@ -377,23 +397,49 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 	var flow rlib.Flow
 	var err error
 
+	var raflowRespData RAFlowResponse
+
 	migrateData := false
 
 	// GET FLOW BY REFNO
 	flow, err = rlib.GetFlowByUserRefNo(ctx, d.BID, UserRefNo)
 	if err != nil {
-		return flow, err
+		return raflowRespData, err
 	}
 	if flow.FlowID <= 0 {
 		err = fmt.Errorf("Rental Agreement Flow not found with given Customer Reference No.: %s", UserRefNo)
-		return flow, err
+		return raflowRespData, err
 	}
 
 	// get unmarshalled raflow data into struct
 	err = json.Unmarshal(flow.Data, &raFlowData)
 	if err != nil {
-		return flow, err
+		return raflowRespData, err
 	}
+
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	raflowRespData.Flow = flow
+
+	// PERFORM BASIC VALIDATION ON FLOW DATA
+	bizlogic.ValidateRAFlowBasic(ctx, &raFlowData, &raflowRespData.BasicCheck)
+
+	// Perform Bizlogic check validation on RAFlow
+	bizlogic.ValidateRAFlowBizLogic(ctx, &raFlowData, &raflowRespData.BasicCheck, flow.ID)
+
+	// CHECK DATA FULFILLED
+	bizlogic.DataFulfilledRAFlow(ctx, &raFlowData, &raflowRespData.DataFulfilled)
+
+	if raflowRespData.BasicCheck.Total > 0 ||
+		!(raflowRespData.DataFulfilled.Dates && raflowRespData.DataFulfilled.People &&
+			raflowRespData.DataFulfilled.Pets && raflowRespData.DataFulfilled.Vehicles &&
+			raflowRespData.DataFulfilled.Rentables && raflowRespData.DataFulfilled.ParentChild &&
+			raflowRespData.DataFulfilled.Tie) {
+		fmt.Println("**************** BasicCheck.Total:", raflowRespData.BasicCheck.Total)
+		return raflowRespData, nil
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////////
 
 	// get meta in modRAFlowMeta, we're going to modify it
 	modRAFlowMeta := raFlowData.Meta
@@ -417,7 +463,7 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 			// MODIFY META DATA
 			err = SetActionMetaData(ctx, d, Action, &modRAFlowMeta)
 			if err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			if Action == rlib.RAActionCompleteMoveIn {
@@ -426,14 +472,14 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 
 		default:
 			err = fmt.Errorf("Invalid Action Taken")
-			return flow, err
+			return raflowRespData, err
 		}
 	case "State":
 		// set location for time as UTC
 		var location *time.Location
 		location, err = time.LoadLocation("UTC")
 		if err != nil {
-			return flow, err
+			return raflowRespData, err
 		}
 
 		// get current time in UTC
@@ -447,13 +493,13 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 		case rlib.RASTATEPendingApproval1:
 			var data RAApprover1Data
 			if err = json.Unmarshal([]byte(d.data), &data); err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			var fullName string
 			fullName, err = getUserFullName(ctx, d.sess.UID)
 			if err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			if data.Decision1 == 1 { // Approved
@@ -477,7 +523,7 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 					var xbiz rlib.XBusiness
 					err = rlib.InitBizInternals(d.BID, &xbiz)
 					if err != nil {
-						return flow, err
+						return raflowRespData, err
 					}
 				}
 				// APPLICATION DECLINED SLSID IN LEASE TERMINATION REASON
@@ -488,7 +534,7 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 				modRAFlowMeta.RAFLAGS = (clearedState | 6)
 			} else {
 				err = fmt.Errorf("approver1 data is not valid")
-				return flow, err
+				return raflowRespData, err
 			}
 
 			modRAFlowMeta.Approver1 = d.sess.UID
@@ -498,13 +544,13 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 		case rlib.RASTATEPendingApproval2:
 			var data RAApprover2Data
 			if err = json.Unmarshal([]byte(d.data), &data); err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			var fullName string
 			fullName, err = getUserFullName(ctx, d.sess.UID)
 			if err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			if data.Decision2 == 1 { // Approved
@@ -532,7 +578,7 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 					var xbiz rlib.XBusiness
 					err = rlib.InitBizInternals(d.BID, &xbiz)
 					if err != nil {
-						return flow, err
+						return raflowRespData, err
 					}
 				}
 				// APPLICATION DECLINED SLSID IN LEASE TERMINATION REASON
@@ -543,7 +589,7 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 				modRAFlowMeta.RAFLAGS = (clearedState | 6)
 			} else {
 				err = fmt.Errorf("approver2 data is not valid")
-				return flow, err
+				return raflowRespData, err
 			}
 
 			modRAFlowMeta.Approver2 = d.sess.UID
@@ -553,13 +599,13 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 		case rlib.RASTATEMoveIn:
 			var data RAMoveInData
 			if err = json.Unmarshal([]byte(d.data), &data); err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			var fullName string
 			fullName, err = getUserFullName(ctx, d.sess.UID)
 			if err != nil {
-				return flow, err
+				return raflowRespData, err
 			}
 
 			modRAFlowMeta.MoveInUID = d.sess.UID
@@ -574,26 +620,27 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 	var modMetaData []byte
 	modMetaData, err = json.Marshal(&modRAFlowMeta)
 	if err != nil {
-		return flow, err
+		return raflowRespData, err
 	}
 
 	err = rlib.UpdateFlowData(ctx, "meta", modMetaData, &flow)
 	if err != nil {
-		return flow, err
+		return raflowRespData, err
 	}
 
 	// GET UPDATED FLOW
 	flow, err = rlib.GetFlowByUserRefNo(ctx, flow.BID, flow.UserRefNo)
 	if err != nil {
-		return flow, err
+		return raflowRespData, err
 	}
+	raflowRespData.Flow = flow
 
 	if migrateData {
 		// migrate data to real table via hook
 		var newRAID int64
 		newRAID, err = Flow2RA(ctx, flow.FlowID)
 		if err != nil {
-			return flow, err
+			return raflowRespData, err
 		}
 
 		// After Migration, flow will be deleted
@@ -608,8 +655,9 @@ func handleRefNoVersion(ctx context.Context, d *ServiceData, foo RAActionDataReq
 			CreateBy:  0,
 			LastModBy: 0,
 		}
+		raflowRespData.Flow = flow
 	}
-	return flow, nil
+	return raflowRespData, nil
 }
 
 func getUserFullName(ctx context.Context, UID int64) (string, error) {


### PR DESCRIPTION
- fees modification on rent dates changes
- update the whole flow instead of flow parts json while saving
- added validation of json data in updateFlow routine
- fixed the TMPASMID proper assignment bug while saving
- fixed the rentcycle for prorated fees - nonrecur cycle
- fixed to hide stop date if fee is non-recur
- display error dot in people form tabs
- removed save&add button from people form
- warning sign in fees grid
- Display error if there is no entry for fees
- integration of validation rules in actions API
- show proper notice to move, document date (in UTC because of date type) and preload it if available